### PR TITLE
Initial

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var inherits = require('inherits')
-var Readable = require('stream').Readable
+var Readable = require('readable-stream').Readable
 
 function AbstractSerializer (rdf) {
   this.rdf = rdf

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/rdf-ext/rdf-serializer-abstract",
   "dependencies": {
-    "inherits": "^2.0.1"
+    "inherits": "^2.0.1",
+    "readable-stream": "^2.2.3"
   }
 }


### PR DESCRIPTION
If you have "readable-stream" in dependencies it breaks stream.Readable function. And while inheriting you get an error because it can't get prototype of Object.